### PR TITLE
patch pcsx2

### DIFF
--- a/scripts/install-pcsx2.sh
+++ b/scripts/install-pcsx2.sh
@@ -124,7 +124,7 @@ Covers = ${__emulation_path:?}/storage/pcsx2/covers
 
 
 [Hotkeys]
-ToggleFullscreen = SDL-0/Start & SDL-0/DPadLeft
+ToggleFullscreen = SDL-3/Back & SDL-3/DPadLeft
 CycleAspectRatio = Keyboard/F6
 CycleInterlaceMode = Keyboard/F5
 CycleMipmapMode = Keyboard/Insert
@@ -139,15 +139,15 @@ LoadStateFromSlot = Keyboard/F3
 SaveStateToSlot = Keyboard/F1
 NextSaveStateSlot = Keyboard/F2
 PreviousSaveStateSlot = Keyboard/Shift & Keyboard/F2
-OpenPauseMenu = SDL-0/Back & SDL-0/DPadUp
+OpenPauseMenu = SDL-3/Back & SDL-3/DPadUp
 ToggleFrameLimit = Keyboard/F4
 TogglePause = Keyboard/F9
 ToggleSlowMotion = Keyboard/Shift & Keyboard/Backtab
 ToggleTurbo = Keyboard/Tab
 HoldTurbo = Keyboard/Period
-SaveStateToSlot1 = SDL-0/Start & SDL-0/DPadUp
-LoadStateFromSlot1 = SDL-0/Start & SDL-0/DPadDown
-ShutdownVM = SDL-0/Back & SDL-0/DPadDown
+SaveStateToSlot1 = SDL-3/Start & SDL-3/DPadUp
+LoadStateFromSlot1 = SDL-3/Start & SDL-3/DPadDown
+ShutdownVM = SDL-3/Back & SDL-3/DPadDown
 
 
 [AutoUpdater]
@@ -159,33 +159,42 @@ RecursivePaths = ${__emulation_path:?}/roms/ps2
 
 
 [Pad1]
-Up = SDL-0/DPadUp
-Right = SDL-0/DPadRight
-Down = SDL-0/DPadDown
-Left = SDL-0/DPadLeft
-Triangle = SDL-0/Y
-Circle = SDL-0/B
-Cross = SDL-0/A
-Square = SDL-0/X
-Select = SDL-0/Back
-Start = SDL-0/Start
-L1 = SDL-0/LeftShoulder
-L2 = SDL-0/+LeftTrigger
-R1 = SDL-0/RightShoulder
-R2 = SDL-0/+RightTrigger
-L3 = SDL-0/LeftStick
-R3 = SDL-0/RightStick
-Analog = SDL-0/Guide
-LUp = SDL-0/-LeftY
-LRight = SDL-0/+LeftX
-LDown = SDL-0/+LeftY
-LLeft = SDL-0/-LeftX
-RUp = SDL-0/-RightY
-RRight = SDL-0/+RightX
-RDown = SDL-0/+RightY
-RLeft = SDL-0/-RightX
-LargeMotor = SDL-0/LargeMotor
-SmallMotor = SDL-0/SmallMotor
+Up = SDL-3/DPadUp
+Right = SDL-3/DPadRight
+Down = SDL-3/DPadDown
+Left = SDL-3/DPadLeft
+Triangle = SDL-3/Y
+Circle = SDL-3/B
+Cross = SDL-3/A
+Square = SDL-3/X
+Select = SDL-3/Back
+Start = SDL-3/Start
+L1 = SDL-3/LeftShoulder
+L2 = SDL-3/+LeftTrigger
+R1 = SDL-3/RightShoulder
+R2 = SDL-3/+RightTrigger
+L3 = SDL-3/LeftStick
+R3 = SDL-3/RightStick
+Analog = SDL-3/Guide
+LUp = SDL-3/-LeftY
+LRight = SDL-3/+LeftX
+LDown = SDL-3/+LeftY
+LLeft = SDL-3/-LeftX
+RUp = SDL-3/-RightY
+RRight = SDL-3/+RightX
+RDown = SDL-3/+RightY
+RLeft = SDL-3/-RightX
+LargeMotor = SDL-3/LargeMotor
+SmallMotor = SDL-3/SmallMotor
+
+
+[EmuCore/GS]
+upscale_multiplier = 3
+
+
+[EmuCore]
+EnableWideScreenPatches = true
+SaveStateOnShutdown = true
 EOF
 fi
 


### PR DESCRIPTION
Adjusted to match global hotkeys and dumb-udev setting controller as SDL3 instead of SDL0 when running unpriv